### PR TITLE
Structs

### DIFF
--- a/examples/hello-mica.rs
+++ b/examples/hello-mica.rs
@@ -3,7 +3,7 @@
 use mica::Engine;
 
 fn main() {
-   let engine = Engine::new();
+   let engine = Engine::new(mica::std::lib());
    mica::std::load(&engine).unwrap();
 
    engine.set("x", 123_i32).unwrap();

--- a/mica-cli/src/main.rs
+++ b/mica-cli/src/main.rs
@@ -42,7 +42,7 @@ impl Completer for MicaValidator {
 
 impl Validator for MicaValidator {
    fn validate(&self, ctx: &mut ValidationContext) -> rustyline::Result<ValidationResult> {
-      let engine = Engine::new();
+      let engine = Engine::new(mica::std::lib());
       if let Err(error) = engine.compile("(repl)", ctx.input()) {
          use LanguageErrorKind as ErrorKind;
          if let Error::Compile(LanguageError::Compile {
@@ -83,10 +83,13 @@ fn interpret(
 }
 
 fn engine(options: &EngineOptions) -> Result<Engine, mica::Error> {
-   let engine = Engine::with_debug_options(mica::DebugOptions {
-      dump_ast: options.dump_ast,
-      dump_bytecode: options.dump_bytecode,
-   });
+   let engine = Engine::with_debug_options(
+      mica::std::lib(),
+      mica::DebugOptions {
+         dump_ast: options.dump_ast,
+         dump_bytecode: options.dump_bytecode,
+      },
+   );
    mica::std::load(&engine)?;
    Ok(engine)
 }

--- a/mica-hl/src/engine.rs
+++ b/mica-hl/src/engine.rs
@@ -2,7 +2,9 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use mica_language::ast::DumpAst;
-use mica_language::bytecode::{Chunk, Environment, Function, FunctionKind, Opr24};
+use mica_language::bytecode::{
+   BuiltinDispatchTables, Chunk, Environment, Function, FunctionKind, Opr24,
+};
 use mica_language::codegen::CodeGenerator;
 use mica_language::lexer::Lexer;
 use mica_language::parser::Parser;
@@ -41,7 +43,7 @@ impl Engine {
    pub fn with_debug_options(debug_options: DebugOptions) -> Self {
       Self {
          runtime_env: Rc::new(RefCell::new(RuntimeEnvironment {
-            env: Environment::new(),
+            env: Environment::new(BuiltinDispatchTables::default()),
             globals: Globals::new(),
          })),
          debug_options,

--- a/mica-hl/src/engine.rs
+++ b/mica-hl/src/engine.rs
@@ -13,7 +13,8 @@ use mica_language::value::{Closure, Value};
 use mica_language::vm::{self, Globals};
 
 use crate::{
-   BuiltType, Error, Fiber, ForeignFunction, StandardLibrary, ToValue, TryFromValue, TypeBuilder,
+   ffvariants, BuiltType, Error, Fiber, ForeignFunction, StandardLibrary, ToValue, TryFromValue,
+   TypeBuilder,
 };
 
 pub use mica_language::bytecode::ForeignFunction as RawForeignFunction;
@@ -194,7 +195,7 @@ impl Engine {
    {
       let mut runtime_env = self.runtime_env.try_borrow_mut().map_err(|_| Error::EngineInUse)?;
       let id = id.to_global_id(&mut runtime_env.env)?;
-      T::try_from_value(runtime_env.globals.get(id.0))
+      T::try_from_value(&runtime_env.globals.get(id.0))
    }
 
    /// Declares a "raw" function in the global scope. Raw functions do not perform any type checks
@@ -243,6 +244,7 @@ impl Engine {
    /// See [`add_raw_function`][`Self::add_raw_function`].
    pub fn add_function<F, V>(&self, name: &str, f: F) -> Result<(), Error>
    where
+      V: ffvariants::Bare,
       F: ForeignFunction<V>,
    {
       self.add_raw_function(name, f.parameter_count(), f.to_raw_foreign_function())

--- a/mica-hl/src/engine.rs
+++ b/mica-hl/src/engine.rs
@@ -73,7 +73,7 @@ impl Engine {
          boolean: Rc::clone(&boolean.instance_dtable),
          number: Rc::clone(&number.instance_dtable),
          string: Rc::clone(&string.instance_dtable),
-         function: Rc::new(DispatchTable::new("Function")), // TODO
+         function: Rc::new(DispatchTable::new_for_instance("Function")), // TODO
       };
 
       let engine = Self {

--- a/mica-hl/src/error.rs
+++ b/mica-hl/src/error.rs
@@ -3,7 +3,9 @@
 use std::borrow::Cow;
 use std::fmt;
 
+/// A raw [`mica-language`][`crate::language`] error, with metadata such as stack traces.
 pub type LanguageError = mica_language::common::Error;
+/// A raw [`mica-language`][`crate::language`] error kind.
 pub type LanguageErrorKind = mica_language::common::ErrorKind;
 
 /// An error.
@@ -121,7 +123,9 @@ where
    }
 }
 
+/// Extensions for converting [`Result`]s into a `mica-language` FFI-friendly structure.
 pub trait MicaLanguageResultExt<T> {
+   /// Maps the error in the result to a [`LanguageErrorKind`].
    fn mica_language(self) -> Result<T, LanguageErrorKind>;
 }
 

--- a/mica-hl/src/error.rs
+++ b/mica-hl/src/error.rs
@@ -19,6 +19,8 @@ pub enum Error {
    TooManyGlobals,
    /// Too many functions were created.
    TooManyFunctions,
+   /// Too many methods with different signatures were declared.
+   TooManyMethods,
    /// A type mismatch occured.
    TypeMismatch {
       expected: Cow<'static, str>,
@@ -32,6 +34,8 @@ pub enum Error {
       expected: Cow<'static, str>,
       got: Cow<'static, str>,
    },
+   /// A value was mutably borrowed twice.
+   ReentrantMutableBorrow,
    /// A user-defined error.
    User(Box<dyn std::error::Error>),
 }
@@ -52,6 +56,7 @@ impl fmt::Display for Error {
          Self::EngineInUse => f.write_str("execution engine is in use by another fiber"),
          Self::TooManyGlobals => f.write_str("too many globals"),
          Self::TooManyFunctions => f.write_str("too many functions"),
+         Self::TooManyMethods => f.write_str("too many methods with different signatures"),
          Self::TypeMismatch { expected, got } => {
             write!(f, "type mismatch, expected {expected} but got {got}")
          }
@@ -65,9 +70,11 @@ impl fmt::Display for Error {
          } => {
             write!(
                f,
-               "type mismatch at argument {index}, expected {expected} but got {got}"
+               "type mismatch at argument {}, expected {expected} but got {got}",
+               index + 1
             )
          }
+         Self::ReentrantMutableBorrow => write!(f, "method receiver mutation is not reentrant"),
          Self::User(error) => write!(f, "{error}"),
       }
    }

--- a/mica-hl/src/fiber.rs
+++ b/mica-hl/src/fiber.rs
@@ -4,7 +4,8 @@ use std::rc::Rc;
 use mica_language::value::Value;
 use mica_language::vm;
 
-use crate::{Error, RuntimeEnvironment, TryFromValue};
+use crate::rtenv::RuntimeEnvironment;
+use crate::{Error, TryFromValue};
 
 /// A fiber represents an independent, pausable thread of code execution.
 ///

--- a/mica-hl/src/fiber.rs
+++ b/mica-hl/src/fiber.rs
@@ -31,7 +31,7 @@ impl Fiber {
          let mut runtime_env = self.runtime_env.try_borrow_mut().map_err(|_| Error::EngineInUse)?;
          let (env, globals) = runtime_env.split();
          let result = self.inner.interpret(env, globals)?;
-         Ok(Some(T::try_from_value(result)?))
+         Ok(Some(T::try_from_value(&result)?))
       }
    }
 
@@ -47,6 +47,6 @@ impl Fiber {
       while let Some(v) = self.resume()? {
          result = v;
       }
-      T::try_from_value(result)
+      T::try_from_value(&result)
    }
 }

--- a/mica-hl/src/function.rs
+++ b/mica-hl/src/function.rs
@@ -166,15 +166,24 @@ pub mod ffvariants {
    // so we put them into a generic parameter here.
    // The PhantomData inside suppresses an "unused generic parameter" error and prevents
    // construction of the two structs (because it's a private field).
+
+   /// A bare fallible function.
    pub struct Fallible<Args>(PhantomData<Args>);
+   /// A bare infallible function.
    pub struct Infallible<Args>(PhantomData<Args>);
+   /// A bare varargs fallible function.
    pub enum VarargsFallible {}
+   /// A bare varargs infallible function.
    pub enum VarargsInfallible {}
 
    // S is the self type (`ImmutableSelf` or `MutableSelf`).
+   /// A fallible function with `RawSelf`.
    pub struct FallibleRawSelf<Args>(PhantomData<Args>);
+   /// An infallible function with `RawSelf`.
    pub struct InfallibleRawSelf<Args>(PhantomData<Args>);
+   /// A fallible function with typed `self`.
    pub struct FallibleSelf<S, Args>(PhantomData<(S, Args)>);
+   /// An infallible function with typed `self`.
    pub struct InfallibleSelf<S, Args>(PhantomData<(S, Args)>);
 
    mod sealed {
@@ -186,11 +195,16 @@ pub mod ffvariants {
       impl<S, Args> Sealed for super::InfallibleSelf<S, Args> {}
    }
 
+   /// Defines the common [`Receiver`][`Self::Receiver`] type of [`ImmutableSelf`]
+   /// and [`MutableSelf`].
    pub trait Receiver {
+      /// The type that receives the method call.
       type Receiver;
    }
 
+   /// Marker for a method that has an immutable `self` (`&self`).
    pub struct ImmutableSelf<S>(PhantomData<S>);
+   /// Marker for a method that has a mutable `self` (`&mut self`).
    pub struct MutableSelf<S>(PhantomData<S>);
 
    impl<S> Receiver for ImmutableSelf<S> {
@@ -201,7 +215,7 @@ pub mod ffvariants {
       type Receiver = S;
    }
 
-   /// Marker trait for all functions that accept a `self` (reference) as the first parameter.
+   /// Marker trait for all functions that accept a `self` reference as the first parameter.
    pub trait Method<S>: sealed::Sealed
    where
       S: ?Sized,

--- a/mica-hl/src/function.rs
+++ b/mica-hl/src/function.rs
@@ -122,11 +122,11 @@ impl<'a> From<&'a Value> for RawSelf<'a> {
 ///     - Each argument: [`TryFromValue`]
 ///     - `R`: [`ToValue`]
 ///   - `fn (Self, A, B, C, ...) -> R` where
-///     - `Self`: [`FromValueSelf`] or [`FromValueSelfMut`]
+///     - `Self`: [`FromValueSelf`][`crate::FromValueSelf`] or [`FromValueSelfMut`][`crate::FromValueSelfMut`]
 ///     - Each argument after `Self`: [`TryFromValue`]
 ///     - `R`: [`ToValue`]
 ///   - `fn (Self, A, B, C, ...) -> Result<R, E>`
-///     - `Self`: [`FromValueSelf`] or [`FromValueSelfMut`]
+///     - `Self`: [`FromValueSelf`][`crate::FromValueSelf`] or [`FromValueSelfMut`][`crate::FromValueSelfMut`]
 ///     - Each argument after `Self`: [`TryFromValue`]
 ///     - `R`: [`ToValue`]
 ///   - Due to a limitation in Rust's type system, a maximum of 8 arguments is supported now.
@@ -138,7 +138,7 @@ impl<'a> From<&'a Value> for RawSelf<'a> {
 ///     - `E`: [`std::error::Error`]
 ///
 /// The generic parameter `V` is not used inside the trait. Its only purpose is to allow for
-/// multiple overlapping implementations of a trait for the same type. See [`fn_variants`] for more
+/// multiple overlapping implementations of a trait for the same type. See [`ffvariants`] for more
 /// information.
 pub trait ForeignFunction<V> {
    /// Returns the number of parameters this function has, or `None` if the function accepts a

--- a/mica-hl/src/function.rs
+++ b/mica-hl/src/function.rs
@@ -122,11 +122,11 @@ impl<'a> From<&'a Value> for RawSelf<'a> {
 ///     - Each argument: [`TryFromValue`]
 ///     - `R`: [`ToValue`]
 ///   - `fn (Self, A, B, C, ...) -> R` where
-///     - `Self`: [`TryFromValueSelf`]
+///     - `Self`: [`FromValueSelf`] or [`FromValueSelfMut`]
 ///     - Each argument after `Self`: [`TryFromValue`]
 ///     - `R`: [`ToValue`]
 ///   - `fn (Self, A, B, C, ...) -> Result<R, E>`
-///     - `Self`: [`TryFromValueSelf`]
+///     - `Self`: [`FromValueSelf`] or [`FromValueSelfMut`]
 ///     - Each argument after `Self`: [`TryFromValue`]
 ///     - `R`: [`ToValue`]
 ///   - Due to a limitation in Rust's type system, a maximum of 8 arguments is supported now.

--- a/mica-hl/src/function.rs
+++ b/mica-hl/src/function.rs
@@ -18,7 +18,10 @@ pub struct Arguments<'a> {
 
 impl<'a> Arguments<'a> {
    fn new(arguments: &'a [Value]) -> Self {
-      Self { inner: arguments }
+      // Skip the first argument, which is `self` (or the currently called function).
+      Self {
+         inner: &arguments[1..],
+      }
    }
 
    /// Returns the number of arguments passed to the function.

--- a/mica-hl/src/lib.rs
+++ b/mica-hl/src/lib.rs
@@ -6,12 +6,16 @@ mod engine;
 mod error;
 mod fiber;
 mod function;
+mod stdlib;
+mod types;
 mod value;
 
 pub use engine::*;
 pub use error::*;
 pub use fiber::*;
 pub use function::*;
+pub use stdlib::*;
+pub use types::*;
 pub use value::*;
 
 pub use mica_language as language;

--- a/mica-hl/src/stdlib.rs
+++ b/mica-hl/src/stdlib.rs
@@ -1,0 +1,18 @@
+use crate::TypeBuilder;
+
+/// Definitions of basic types provided by a standard library.
+///
+/// This role is usually fulfilled by the [`mica-std`](https://crates.io/crate/mica-std) crate.
+pub trait StandardLibrary {
+   /// Defines the `Nil` type using the given struct builder.
+   fn define_nil(&mut self, builder: &mut TypeBuilder<()>);
+
+   /// Defines the `Boolean` type using the given struct builder.
+   fn define_boolean(&mut self, builder: &mut TypeBuilder<bool>);
+
+   /// Defines the `Number` type using the given struct builder.
+   fn define_number(&mut self, builder: &mut TypeBuilder<f64>);
+
+   /// Defines the `String` type using the given struct builder.
+   fn define_string(&mut self, builder: &mut TypeBuilder<&str>);
+}

--- a/mica-hl/src/stdlib.rs
+++ b/mica-hl/src/stdlib.rs
@@ -2,17 +2,17 @@ use crate::TypeBuilder;
 
 /// Definitions of basic types provided by a standard library.
 ///
-/// This role is usually fulfilled by the [`mica-std`](https://crates.io/crate/mica-std) crate.
+/// This role is usually fulfilled by the [`mica-std`](https://crates.io/crates/mica-std) crate.
 pub trait StandardLibrary {
-   /// Defines the `Nil` type using the given struct builder.
+   /// Defines the `Nil` type using the given type builder.
    fn define_nil(&mut self, builder: &mut TypeBuilder<()>);
 
-   /// Defines the `Boolean` type using the given struct builder.
+   /// Defines the `Boolean` type using the given type builder.
    fn define_boolean(&mut self, builder: &mut TypeBuilder<bool>);
 
-   /// Defines the `Number` type using the given struct builder.
+   /// Defines the `Number` type using the given type builder.
    fn define_number(&mut self, builder: &mut TypeBuilder<f64>);
 
-   /// Defines the `String` type using the given struct builder.
+   /// Defines the `String` type using the given type builder.
    fn define_string(&mut self, builder: &mut TypeBuilder<&str>);
 }

--- a/mica-hl/src/stdlib.rs
+++ b/mica-hl/src/stdlib.rs
@@ -1,18 +1,19 @@
 use crate::TypeBuilder;
 
 /// Definitions of basic types provided by a standard library.
-///
 /// This role is usually fulfilled by the [`mica-std`](https://crates.io/crates/mica-std) crate.
+///
+/// Each function must return the original builder, possibly with functions added into it.
 pub trait StandardLibrary {
    /// Defines the `Nil` type using the given type builder.
-   fn define_nil(&mut self, builder: &mut TypeBuilder<()>);
+   fn define_nil(&mut self, builder: TypeBuilder<()>) -> TypeBuilder<()>;
 
    /// Defines the `Boolean` type using the given type builder.
-   fn define_boolean(&mut self, builder: &mut TypeBuilder<bool>);
+   fn define_boolean(&mut self, builder: TypeBuilder<bool>) -> TypeBuilder<bool>;
 
    /// Defines the `Number` type using the given type builder.
-   fn define_number(&mut self, builder: &mut TypeBuilder<f64>);
+   fn define_number(&mut self, builder: TypeBuilder<f64>) -> TypeBuilder<f64>;
 
    /// Defines the `String` type using the given type builder.
-   fn define_string(&mut self, builder: &mut TypeBuilder<&str>);
+   fn define_string(&mut self, builder: TypeBuilder<str>) -> TypeBuilder<str>;
 }

--- a/mica-hl/src/stdlib.rs
+++ b/mica-hl/src/stdlib.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use crate::TypeBuilder;
 
 /// Definitions of basic types provided by a standard library.
@@ -15,5 +17,5 @@ pub trait StandardLibrary {
    fn define_number(&mut self, builder: TypeBuilder<f64>) -> TypeBuilder<f64>;
 
    /// Defines the `String` type using the given type builder.
-   fn define_string(&mut self, builder: TypeBuilder<str>) -> TypeBuilder<str>;
+   fn define_string(&mut self, builder: TypeBuilder<Rc<str>>) -> TypeBuilder<Rc<str>>;
 }

--- a/mica-hl/src/types.rs
+++ b/mica-hl/src/types.rs
@@ -1,0 +1,118 @@
+use std::marker::PhantomData;
+use std::rc::Rc;
+
+use mica_language::bytecode::{
+   DispatchTable, Environment, Function, FunctionKind, FunctionSignature,
+};
+use mica_language::value::Closure;
+
+use crate::{ffvariants, Error, ForeignFunction, RawForeignFunction};
+
+/// A descriptor for a dispatch table. Defines which methods are available on the table, as well
+/// as their implementations.
+#[derive(Default)]
+pub(crate) struct DispatchTableDescriptor {
+   methods: Vec<(FunctionSignature, RawForeignFunction)>,
+}
+
+impl DispatchTableDescriptor {
+   /// Builds a dispatch table from this descriptor.
+   pub(crate) fn build_dtable(
+      self,
+      type_name: Rc<str>,
+      env: &mut Environment,
+   ) -> Result<DispatchTable, Error> {
+      let mut dtable = DispatchTable::new(type_name);
+      for (signature, f) in self.methods {
+         let function_id = env
+            .create_function(Function {
+               name: Rc::clone(&signature.name),
+               parameter_count: signature.arity,
+               kind: FunctionKind::Foreign(f),
+            })
+            .map_err(|_| Error::TooManyFunctions)?;
+         let index = env.get_method_index(&signature).map_err(|_| Error::TooManyMethods)?;
+         dtable.set_method(
+            index,
+            Rc::new(Closure {
+               function_id,
+               captures: Vec::new(),
+            }),
+         );
+      }
+      Ok(dtable)
+   }
+}
+
+/// A builder that allows for binding APIs with user-defined types.
+pub struct TypeBuilder<T>
+where
+   T: ?Sized,
+{
+   type_name: Rc<str>,
+   type_dtable: DispatchTableDescriptor,
+   instance_dtable: DispatchTableDescriptor,
+   _data: PhantomData<T>,
+}
+
+impl<T> TypeBuilder<T>
+where
+   T: ?Sized,
+{
+   /// Creates a new `StructBuilder`.
+   pub fn new(type_name: impl Into<Rc<str>>) -> Self {
+      let type_name = type_name.into();
+      Self {
+         type_dtable: Default::default(),
+         instance_dtable: Default::default(),
+         type_name,
+         _data: PhantomData,
+      }
+   }
+
+   /// Adds a _raw_ instance function to the struct.
+   ///
+   /// You should generally prefer [`add_function`][`Self::add_function`] instead of this.
+   ///
+   /// `parameter_count` should reflect the parameter count of the function. Pass `None` if the
+   /// function accepts a variable number of arguments. Note that _unlike with bare raw functions_
+   /// there can be two functions with the same name defined on a type, as long as they have
+   /// different arities. Functions with specific arities take priority over varargs.
+   pub fn add_raw_function(
+      &mut self,
+      name: &str,
+      parameter_count: Option<u16>,
+      f: RawForeignFunction,
+   ) -> &mut Self {
+      self.instance_dtable.methods.push((
+         FunctionSignature {
+            name: Rc::from(name),
+            arity: parameter_count,
+         },
+         f,
+      ));
+      self
+   }
+
+   /// Adds an instance function to the struct.
+   pub fn add_function<F, V>(&mut self, name: &str, f: F) -> &mut Self
+   where
+      V: ffvariants::Method,
+      F: ForeignFunction<V>,
+   {
+      self.add_raw_function(name, f.parameter_count(), f.to_raw_foreign_function())
+   }
+
+   /// Destrutcures the struct builder into its type dtable and instance dtable, respectively.
+   pub(crate) fn build_dtables(
+      self,
+      env: &mut Environment,
+   ) -> Result<(DispatchTable, DispatchTable), Error> {
+      Ok((
+         self.type_dtable.build_dtable(Rc::clone(&self.type_name), env)?,
+         self
+            .instance_dtable
+            .build_dtable(Rc::from(format!("type {}", &self.type_name).as_str()), env)?,
+      ))
+   }
+}

--- a/mica-hl/src/types.rs
+++ b/mica-hl/src/types.rs
@@ -97,7 +97,7 @@ where
    /// Adds an instance function to the struct.
    pub fn add_function<F, V>(&mut self, name: &str, f: F) -> &mut Self
    where
-      V: ffvariants::Method,
+      V: ffvariants::Method<T>,
       F: ForeignFunction<V>,
    {
       self.add_raw_function(name, f.parameter_count(), f.to_raw_foreign_function())

--- a/mica-hl/src/types.rs
+++ b/mica-hl/src/types.rs
@@ -59,7 +59,7 @@ impl<T> TypeBuilder<T>
 where
    T: ?Sized,
 {
-   /// Creates a new `StructBuilder`.
+   /// Creates a new `TypeBuilder`.
    pub fn new(type_name: impl Into<Rc<str>>) -> Self {
       let type_name = type_name.into();
       Self {

--- a/mica-hl/src/value.rs
+++ b/mica-hl/src/value.rs
@@ -151,7 +151,7 @@ where
    }
 }
 
-/// Implemented by all types that can come from a `self` parameter.
+/// Implemented by all types that can be a `&self` parameter in an instance function.
 ///
 /// This should never be implemented manually unless you know what you're doing.
 pub trait FromValueSelf
@@ -194,6 +194,7 @@ impl FromValueSelf for f64 {
    }
 }
 
+/// Implemented by all types that can be a `&mut self` parameter in an instance function.
 pub trait FromValueSelfMut
 where
    Self: Sized,

--- a/mica-hl/src/value.rs
+++ b/mica-hl/src/value.rs
@@ -65,6 +65,12 @@ impl ToValue for String {
    }
 }
 
+impl ToValue for Rc<str> {
+   fn to_value(&self) -> Value {
+      Value::String(Rc::clone(self))
+   }
+}
+
 impl<T> ToValue for Option<T>
 where
    T: ToValue,
@@ -159,10 +165,7 @@ where
 /// Implemented by all types that can be a `&self` parameter in an instance function.
 ///
 /// This should never be implemented manually unless you know what you're doing.
-pub trait FromValueSelf
-where
-   Self: Sized,
-{
+pub trait FromValueSelf {
    /// Returns a shared reference to `Self` **without checking that the value is of the correct
    /// type**.
    ///
@@ -194,6 +197,15 @@ impl FromValueSelf for f64 {
    unsafe fn from_value_self(v: &Value) -> &Self {
       match v {
          Value::Number(n) => n,
+         _ => unreachable_unchecked(),
+      }
+   }
+}
+
+impl FromValueSelf for Rc<str> {
+   unsafe fn from_value_self(v: &Value) -> &Self {
+      match v {
+         Value::String(s) => s,
          _ => unreachable_unchecked(),
       }
    }

--- a/mica-language/src/ast.rs
+++ b/mica-language/src/ast.rs
@@ -211,6 +211,8 @@ pub enum NodeKind {
    Parameters,
    Call,
    Return,
+
+   Struct,
 }
 
 /// A `Debug` formatter that pretty-prints ASTs.

--- a/mica-language/src/ast.rs
+++ b/mica-language/src/ast.rs
@@ -70,7 +70,7 @@ impl Ast {
       None
    }
 
-   pub fn string(&self, node: NodeId) -> Option<&str> {
+   pub fn string(&self, node: NodeId) -> Option<&Rc<str>> {
       if let Some(NodeData::String(s)) = unsafe { self.data.get_unchecked(node.0 as usize) } {
          return Some(s);
       }

--- a/mica-language/src/ast.rs
+++ b/mica-language/src/ast.rs
@@ -199,6 +199,7 @@ pub enum NodeKind {
 
    Assign,
    Dot,
+   Field,
 
    Main,
    Do,

--- a/mica-language/src/ast.rs
+++ b/mica-language/src/ast.rs
@@ -22,7 +22,7 @@ pub struct Ast {
 
 enum NodeData {
    Number(f64),
-   String(String),
+   String(Rc<str>),
    Children(Vec<NodeId>),
 }
 
@@ -118,7 +118,7 @@ impl<'a> NodeBuilder<'a> {
       self
    }
 
-   pub fn with_string(self, string: String) -> Self {
+   pub fn with_string(self, string: Rc<str>) -> Self {
       unsafe {
          *self.ast.data.get_unchecked_mut(self.node.0 as usize) = Some(NodeData::String(string));
       }

--- a/mica-language/src/ast.rs
+++ b/mica-language/src/ast.rs
@@ -198,6 +198,7 @@ pub enum NodeKind {
    GreaterEqual,
 
    Assign,
+   Dot,
 
    Main,
    Do,

--- a/mica-language/src/ast.rs
+++ b/mica-language/src/ast.rs
@@ -210,10 +210,13 @@ pub enum NodeKind {
 
    Func,
    Parameters,
+   Static,
+   Constructor,
    Call,
    Return,
 
    Struct,
+   Impl,
 }
 
 /// A `Debug` formatter that pretty-prints ASTs.

--- a/mica-language/src/bytecode.rs
+++ b/mica-language/src/bytecode.rs
@@ -593,6 +593,8 @@ impl Environment {
 pub struct DispatchTable {
    /// The name of the type this dispatch table contains functions for.
    pub type_name: Rc<str>,
+   /// The "child" dispatch table that holds instance methods.
+   pub instance: Option<Rc<DispatchTable>>,
    /// The functions in this dispatch table.
    methods: Vec<Option<Rc<Closure>>>,
 }
@@ -602,6 +604,7 @@ impl DispatchTable {
    pub fn new(type_name: impl Into<Rc<str>>) -> Self {
       Self {
          type_name: type_name.into(),
+         instance: None,
          methods: Vec::new(),
       }
    }

--- a/mica-language/src/bytecode.rs
+++ b/mica-language/src/bytecode.rs
@@ -105,6 +105,7 @@ impl PackableToOpr24 for (u16, u8) {
 #[repr(u8)]
 pub enum Opcode {
    /// Doesn't do anything. Used as a default zero value if something goes wrong.
+   /// Also used for backpatching purposes.
    #[allow(unused)]
    Nop,
 
@@ -123,6 +124,9 @@ pub enum Opcode {
    /// Creates a unique type that can be later implemented. Must be followed by a string indicating
    /// the type's name.
    CreateType,
+   /// Creates a struct instance from the type at the top of the stack, with the specified amount
+   /// of fields.
+   CreateStruct(Opr24),
 
    /// Assigns the value at the top of the stack to a global. The value stays on the stack.
    AssignGlobal(Opr24),
@@ -138,6 +142,13 @@ pub enum Opcode {
    GetUpvalue(Opr24),
    /// Closes a local in its upvalue.
    CloseLocal(Opr24),
+   /// Loads a field from the struct on the top of the stack.
+   /// Assumes the value on top is a struct and not something else.
+   GetField(Opr24),
+   /// Assigns to a field in the struct on the top of the stack. The struct is consumed but the
+   /// value remains on the stack.
+   /// Assumes the second value from top is a struct and not something else.
+   AssignField(Opr24),
 
    /// Swaps the two values at the top of the stack.
    Swap,

--- a/mica-language/src/bytecode.rs
+++ b/mica-language/src/bytecode.rs
@@ -523,13 +523,10 @@ impl DispatchTable {
    }
 }
 
-/// Dispatch tables for builtin types.
-pub(crate) struct BuiltinDispatchTables {
-   /// The dispatch table of newly created types.
-   pub(crate) newtype: Rc<DispatchTable>,
-
-   pub(crate) nil: Rc<DispatchTable>,
-   pub(crate) boolean: Rc<DispatchTable>,
-   pub(crate) number: Rc<DispatchTable>,
-   pub(crate) string: Rc<DispatchTable>,
+/// Dispatch tables for builtin types. These should be constructed by the standard library.
+pub struct BuiltinDispatchTables {
+   pub nil: Rc<DispatchTable>,
+   pub boolean: Rc<DispatchTable>,
+   pub number: Rc<DispatchTable>,
+   pub string: Rc<DispatchTable>,
 }

--- a/mica-language/src/bytecode.rs
+++ b/mica-language/src/bytecode.rs
@@ -86,6 +86,9 @@ pub enum Opcode {
    PushString,
    /// Creates a closure from the function with the given ID and pushes it onto the stack.
    CreateClosure(Opr24),
+   /// Creates a unique type that can be later implemented. Must be followed by a string indicating
+   /// the type's name.
+   CreateType,
 
    /// Assigns the value at the top of the stack to a global. The value stays on the stack.
    AssignGlobal(Opr24),
@@ -367,7 +370,9 @@ impl Debug for Chunk {
          #[allow(clippy::single_match)]
          match opcode {
             Opcode::PushNumber => write!(f, "{}", unsafe { self.read_number(&mut pc) })?,
-            Opcode::PushString => write!(f, "{:?}", unsafe { self.read_string(&mut pc) })?,
+            Opcode::PushString | Opcode::CreateType => {
+               write!(f, "{:?}", unsafe { self.read_string(&mut pc) })?
+            }
             | Opcode::JumpForward(amount)
             | Opcode::JumpForwardIfFalsy(amount)
             | Opcode::JumpForwardIfTruthy(amount) => {

--- a/mica-language/src/bytecode.rs
+++ b/mica-language/src/bytecode.rs
@@ -450,14 +450,17 @@ pub struct Environment {
    globals: HashMap<String, Opr24>,
    /// Functions in the environment.
    functions: Vec<Function>,
+   /// Dispatch tables for builtin types.
+   builtin_dtables: BuiltinDispatchTables,
 }
 
 impl Environment {
    /// Creates a new, empty environment.
-   pub fn new() -> Self {
+   pub fn new(builtin_dtables: BuiltinDispatchTables) -> Self {
       Self {
          globals: HashMap::new(),
          functions: Vec::new(),
+         builtin_dtables,
       }
    }
 
@@ -499,13 +502,8 @@ impl Environment {
    }
 }
 
-impl Default for Environment {
-   fn default() -> Self {
-      Self::new()
-   }
-}
-
 /// A dispatch table containing functions bound to an instance of a value.
+#[derive(Debug)]
 pub struct DispatchTable {
    /// The name of the type this dispatch table contains functions for.
    pub type_name: Rc<str>,
@@ -524,9 +522,22 @@ impl DispatchTable {
 }
 
 /// Dispatch tables for builtin types. These should be constructed by the standard library.
+#[derive(Debug)]
 pub struct BuiltinDispatchTables {
    pub nil: Rc<DispatchTable>,
    pub boolean: Rc<DispatchTable>,
    pub number: Rc<DispatchTable>,
    pub string: Rc<DispatchTable>,
+}
+
+/// Default dispatch tables for built-in types are empty and do not implement any methods.
+impl Default for BuiltinDispatchTables {
+   fn default() -> Self {
+      Self {
+         nil: Rc::new(DispatchTable::new("Nil")),
+         boolean: Rc::new(DispatchTable::new("Boolean")),
+         number: Rc::new(DispatchTable::new("Number")),
+         string: Rc::new(DispatchTable::new("String")),
+      }
+   }
 }

--- a/mica-language/src/bytecode.rs
+++ b/mica-language/src/bytecode.rs
@@ -515,7 +515,7 @@ pub struct Environment {
    /// Mapping from method indices to function signatures.
    function_signatures: Vec<FunctionSignature>,
    /// Dispatch tables for builtin types.
-   pub(crate) builtin_dtables: BuiltinDispatchTables,
+   pub builtin_dtables: BuiltinDispatchTables,
 }
 
 impl Environment {
@@ -599,9 +599,9 @@ pub struct DispatchTable {
 
 impl DispatchTable {
    /// Creates a new, empty dispatch table for a type with the given name.
-   pub fn new(type_name: &str) -> Self {
+   pub fn new(type_name: impl Into<Rc<str>>) -> Self {
       Self {
-         type_name: Rc::from(type_name),
+         type_name: type_name.into(),
          methods: Vec::new(),
       }
    }
@@ -610,9 +610,19 @@ impl DispatchTable {
    pub fn get_method(&self, index: u16) -> Option<&Rc<Closure>> {
       self.methods.get(index as usize).into_iter().flatten().next()
    }
+
+   /// Adds a method into the dispatch table.
+   pub fn set_method(&mut self, index: u16, closure: Rc<Closure>) {
+      let index = index as usize;
+      if index >= self.methods.len() {
+         self.methods.resize(index + 1, None);
+      }
+      self.methods[index] = Some(closure);
+   }
 }
 
-/// Dispatch tables for builtin types. These should be constructed by the standard library.
+/// Dispatch tables for instances of builtin types. These should be constructed by the standard
+/// library.
 #[derive(Debug)]
 pub struct BuiltinDispatchTables {
    pub nil: Rc<DispatchTable>,

--- a/mica-language/src/bytecode.rs
+++ b/mica-language/src/bytecode.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 use bytemuck::{Pod, Zeroable};
 
 use crate::common::{ErrorKind, Location};
-use crate::value::Value;
+use crate::value::{Closure, Value};
 
 /// A 24-bit integer encoding an instruction operand.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
@@ -503,4 +503,33 @@ impl Default for Environment {
    fn default() -> Self {
       Self::new()
    }
+}
+
+/// A dispatch table containing functions bound to an instance of a value.
+pub struct DispatchTable {
+   /// The name of the type this dispatch table contains functions for.
+   pub type_name: Rc<str>,
+   /// The functions in this dispatch table.
+   pub(crate) functions: Vec<Option<Closure>>,
+}
+
+impl DispatchTable {
+   /// Creates a new, empty dispatch table for a type with the given name.
+   pub fn new(type_name: &str) -> Self {
+      Self {
+         type_name: Rc::from(type_name),
+         functions: Vec::new(),
+      }
+   }
+}
+
+/// Dispatch tables for builtin types.
+pub(crate) struct BuiltinDispatchTables {
+   /// The dispatch table of newly created types.
+   pub(crate) newtype: Rc<DispatchTable>,
+
+   pub(crate) nil: Rc<DispatchTable>,
+   pub(crate) boolean: Rc<DispatchTable>,
+   pub(crate) number: Rc<DispatchTable>,
+   pub(crate) string: Rc<DispatchTable>,
 }

--- a/mica-language/src/codegen.rs
+++ b/mica-language/src/codegen.rs
@@ -620,6 +620,21 @@ impl<'e> CodeGenerator<'e> {
       Ok(())
    }
 
+   /// Generates code for a struct declaration.
+   fn generate_struct(&mut self, ast: &Ast, node: NodeId) -> Result<(), Error> {
+      let (name, _) = ast.node_pair(node);
+      let name = ast.string(name).unwrap();
+
+      self.chunk.push(Opcode::CreateType);
+      self.chunk.push_string(name);
+      let variable = self
+         .create_variable(name, VariableAllocation::Allocate)
+         .map_err(|kind| ast.error(node, kind))?;
+      self.generate_variable_assign(variable);
+
+      Ok(())
+   }
+
    /// Generates code for a single node.
    fn generate_node(&mut self, ast: &Ast, node: NodeId) -> Result<(), Error> {
       let previous_codegen_location = self.chunk.codegen_location;
@@ -663,7 +678,7 @@ impl<'e> CodeGenerator<'e> {
          NodeKind::Call => self.generate_call(ast, node)?,
          NodeKind::Return => todo!("return is NYI"),
 
-         NodeKind::Struct => todo!("structs are NYI"),
+         NodeKind::Struct => self.generate_struct(ast, node)?,
 
          NodeKind::IfBranch | NodeKind::ElseBranch | NodeKind::Parameters => {
             unreachable!("AST implementation detail")

--- a/mica-language/src/codegen.rs
+++ b/mica-language/src/codegen.rs
@@ -668,6 +668,7 @@ impl<'e> CodeGenerator<'e> {
          NodeKind::Or => self.generate_or(ast, node)?,
 
          NodeKind::Assign => self.generate_assignment(ast, node)?,
+         NodeKind::Dot => todo!("dot operators are NYI"),
 
          NodeKind::Main => self.generate_node_list(ast, ast.children(node).unwrap())?,
 

--- a/mica-language/src/codegen.rs
+++ b/mica-language/src/codegen.rs
@@ -631,6 +631,8 @@ impl<'e> CodeGenerator<'e> {
          .create_variable(name, VariableAllocation::Allocate)
          .map_err(|kind| ast.error(node, kind))?;
       self.generate_variable_assign(variable);
+      self.chunk.push(Opcode::Discard);
+      self.generate_nil();
 
       Ok(())
    }

--- a/mica-language/src/codegen.rs
+++ b/mica-language/src/codegen.rs
@@ -740,8 +740,13 @@ impl<'e> CodeGenerator<'e> {
          NodeKind::Return => todo!("return is NYI"),
 
          NodeKind::Struct => self.generate_struct(ast, node)?,
+         NodeKind::Impl => todo!("impl is NYI"),
 
-         NodeKind::IfBranch | NodeKind::ElseBranch | NodeKind::Parameters => {
+         | NodeKind::IfBranch
+         | NodeKind::ElseBranch
+         | NodeKind::Parameters
+         | NodeKind::Static
+         | NodeKind::Constructor => {
             unreachable!("AST implementation detail")
          }
       }

--- a/mica-language/src/codegen.rs
+++ b/mica-language/src/codegen.rs
@@ -663,6 +663,8 @@ impl<'e> CodeGenerator<'e> {
          NodeKind::Call => self.generate_call(ast, node)?,
          NodeKind::Return => todo!("return is NYI"),
 
+         NodeKind::Struct => todo!("structs are NYI"),
+
          NodeKind::IfBranch | NodeKind::ElseBranch | NodeKind::Parameters => {
             unreachable!("AST implementation detail")
          }

--- a/mica-language/src/common.rs
+++ b/mica-language/src/common.rs
@@ -80,6 +80,9 @@ pub enum ErrorKind {
    MissingMethodName,
    TooManyImpls,
    MethodAlreadyImplemented(FunctionSignature),
+   TooManyFields,
+   FieldDoesNotExist(Rc<str>),
+   FieldOutsideOfImpl,
 
    // Runtime
    TypeError {
@@ -139,6 +142,11 @@ impl std::fmt::Display for ErrorKind {
          Self::MethodAlreadyImplemented(signature) => {
             write!(f, "method {signature} is already implemented")
          }
+         Self::TooManyFields => write!(f, "too many fields"),
+         Self::FieldOutsideOfImpl => {
+            write!(f, "fields cannot be referenced outside of 'impl' blocks")
+         }
+         Self::FieldDoesNotExist(name) => write!(f, "field '@{name}' does not exist"),
 
          Self::TypeError { expected, got } => {
             write!(f, "type mismatch, expected {expected} but got {got}")

--- a/mica-language/src/common.rs
+++ b/mica-language/src/common.rs
@@ -75,6 +75,11 @@ pub enum ErrorKind {
    TooManyParameters,
    TooManyMethods,
    InvalidMethodName,
+   FunctionKindOutsideImpl,
+   InvalidImplItem,
+   MissingMethodName,
+   TooManyImpls,
+   MethodAlreadyImplemented(FunctionSignature),
 
    // Runtime
    TypeError {
@@ -85,6 +90,7 @@ pub enum ErrorKind {
       type_name: Rc<str>,
       signature: FunctionSignature,
    },
+   StructAlreadyImplemented,
    User(Box<dyn std::error::Error>),
 }
 
@@ -123,6 +129,16 @@ impl std::fmt::Display for ErrorKind {
          Self::TooManyParameters => write!(f, "too many parameters"),
          Self::TooManyMethods => write!(f, "too many instance functions with different signatures"),
          Self::InvalidMethodName => write!(f, "method name must be an identifier"),
+         Self::FunctionKindOutsideImpl => write!(
+            f,
+            "function kinds (static, constructor) can only be used in 'impl' blocks"
+         ),
+         Self::InvalidImplItem => write!(f, "only functions are allowed in 'impl' blocks"),
+         Self::MissingMethodName => write!(f, "missing method name"),
+         Self::TooManyImpls => write!(f, "too many 'impl' blocks"),
+         Self::MethodAlreadyImplemented(signature) => {
+            write!(f, "method {signature} is already implemented")
+         }
 
          Self::TypeError { expected, got } => {
             write!(f, "type mismatch, expected {expected} but got {got}")
@@ -131,6 +147,7 @@ impl std::fmt::Display for ErrorKind {
             type_name,
             signature,
          } => write!(f, "method {} is not defined for {}", signature, type_name),
+         Self::StructAlreadyImplemented => write!(f, "this struct is already implemented"),
          Self::User(error) => write!(f, "{}", error),
       }
    }

--- a/mica-language/src/common.rs
+++ b/mica-language/src/common.rs
@@ -1,6 +1,8 @@
 use std::borrow::Cow;
 use std::rc::Rc;
 
+use crate::bytecode::FunctionSignature;
+
 #[derive(Debug, Clone, Copy)]
 pub struct Location {
    pub byte: usize,
@@ -58,7 +60,7 @@ pub enum ErrorKind {
    CommaExpected,
 
    // Code generator
-   VariableDoesNotExist(String),
+   VariableDoesNotExist(Rc<str>),
    TooManyLocals,
    TooManyGlobals,
    TooManyCaptures,
@@ -71,6 +73,11 @@ pub enum ErrorKind {
    TooManyArguments,
    TooManyParameters,
    TooManyMethods,
+   InvalidMethodName,
+   MethodDoesNotExist {
+      type_name: Rc<str>,
+      signature: FunctionSignature,
+   },
 
    // Runtime
    TypeError {
@@ -114,6 +121,11 @@ impl std::fmt::Display for ErrorKind {
          Self::TooManyArguments => write!(f, "too many arguments"),
          Self::TooManyParameters => write!(f, "too many parameters"),
          Self::TooManyMethods => write!(f, "too many instance functions with different signatures"),
+         Self::InvalidMethodName => write!(f, "method name must be an identifier"),
+         Self::MethodDoesNotExist {
+            type_name,
+            signature,
+         } => write!(f, "method {} is not defined for {}", signature, type_name),
 
          Self::TypeError { expected, got } => {
             write!(f, "type mismatch, expected {expected} but got {got}")

--- a/mica-language/src/common.rs
+++ b/mica-language/src/common.rs
@@ -61,6 +61,7 @@ pub enum ErrorKind {
 
    // Code generator
    VariableDoesNotExist(Rc<str>),
+   InvalidAssignment,
    TooManyLocals,
    TooManyGlobals,
    TooManyCaptures,
@@ -74,17 +75,16 @@ pub enum ErrorKind {
    TooManyParameters,
    TooManyMethods,
    InvalidMethodName,
-   MethodDoesNotExist {
-      type_name: Rc<str>,
-      signature: FunctionSignature,
-   },
 
    // Runtime
    TypeError {
       expected: Cow<'static, str>,
       got: Cow<'static, str>,
    },
-   InvalidAssignment,
+   MethodDoesNotExist {
+      type_name: Rc<str>,
+      signature: FunctionSignature,
+   },
    User(Box<dyn std::error::Error>),
 }
 
@@ -109,6 +109,7 @@ impl std::fmt::Display for ErrorKind {
          Self::CommaExpected => write!(f, "comma ',' expected"),
 
          Self::VariableDoesNotExist(name) => write!(f, "variable '{name}' does not exist"),
+         Self::InvalidAssignment => write!(f, "invalid left hand side of assignment"),
          Self::TooManyLocals => write!(f, "too many local variables"),
          Self::TooManyGlobals => write!(f, "too many global variables"),
          Self::TooManyCaptures => write!(f, "too many variables captured in the closure"),
@@ -122,15 +123,14 @@ impl std::fmt::Display for ErrorKind {
          Self::TooManyParameters => write!(f, "too many parameters"),
          Self::TooManyMethods => write!(f, "too many instance functions with different signatures"),
          Self::InvalidMethodName => write!(f, "method name must be an identifier"),
-         Self::MethodDoesNotExist {
-            type_name,
-            signature,
-         } => write!(f, "method {} is not defined for {}", signature, type_name),
 
          Self::TypeError { expected, got } => {
             write!(f, "type mismatch, expected {expected} but got {got}")
          }
-         Self::InvalidAssignment => write!(f, "invalid left hand side of assignment"),
+         Self::MethodDoesNotExist {
+            type_name,
+            signature,
+         } => write!(f, "method {} is not defined for {}", signature, type_name),
          Self::User(error) => write!(f, "{}", error),
       }
    }

--- a/mica-language/src/common.rs
+++ b/mica-language/src/common.rs
@@ -83,6 +83,7 @@ pub enum ErrorKind {
    TooManyFields,
    FieldDoesNotExist(Rc<str>),
    FieldOutsideOfImpl,
+   MissingFields(Vec<Rc<str>>),
 
    // Runtime
    TypeError {
@@ -147,6 +148,14 @@ impl std::fmt::Display for ErrorKind {
             write!(f, "fields cannot be referenced outside of 'impl' blocks")
          }
          Self::FieldDoesNotExist(name) => write!(f, "field '@{name}' does not exist"),
+         Self::MissingFields(fields) => {
+            let fields: Vec<_> = fields.iter().map(|name| format!("@{name}")).collect();
+            let fields = fields.join(", ");
+            write!(
+               f,
+               "the following fields were not assigned in this constructor: {fields}"
+            )
+         }
 
          Self::TypeError { expected, got } => {
             write!(f, "type mismatch, expected {expected} but got {got}")

--- a/mica-language/src/common.rs
+++ b/mica-language/src/common.rs
@@ -70,6 +70,7 @@ pub enum ErrorKind {
    TooManyFunctions,
    TooManyArguments,
    TooManyParameters,
+   TooManyMethods,
 
    // Runtime
    TypeError {
@@ -112,6 +113,7 @@ impl std::fmt::Display for ErrorKind {
          Self::TooManyFunctions => write!(f, "too many unique functions"),
          Self::TooManyArguments => write!(f, "too many arguments"),
          Self::TooManyParameters => write!(f, "too many parameters"),
+         Self::TooManyMethods => write!(f, "too many instance functions with different signatures"),
 
          Self::TypeError { expected, got } => {
             write!(f, "type mismatch, expected {expected} but got {got}")

--- a/mica-language/src/lexer.rs
+++ b/mica-language/src/lexer.rs
@@ -45,6 +45,7 @@ pub enum TokenKind {
 
    Assign, // =
    Dot,    // .
+   At,     // @
 
    LeftParen,  // (
    RightParen, // )
@@ -281,6 +282,7 @@ impl Lexer {
          }
 
          '.' => Ok(self.single_char_token(TokenKind::Dot)),
+         '@' => Ok(self.single_char_token(TokenKind::At)),
 
          '(' => Ok(self.single_char_token(TokenKind::LeftParen)),
          ')' => Ok(self.single_char_token(TokenKind::RightParen)),

--- a/mica-language/src/lexer.rs
+++ b/mica-language/src/lexer.rs
@@ -130,8 +130,15 @@ impl Lexer {
          self.advance();
       }
       if self.get() == '.' {
+         let dot = self.location.byte;
          self.advance();
-         if !matches!(self.get(), '0'..='9') {
+         if Self::is_identifier_start_char(self.get()) {
+            self.location.byte = dot;
+         } else if let '0'..='9' = self.get() {
+            while let '0'..='9' = self.get() {
+               self.advance();
+            }
+         } else {
             return Err(self.error(ErrorKind::MissingDigitsAfterDecimalPoint));
          }
       }

--- a/mica-language/src/lexer.rs
+++ b/mica-language/src/lexer.rs
@@ -5,9 +5,9 @@ use crate::common::{Error, ErrorKind, Location};
 #[derive(Debug, Clone, PartialEq)]
 pub enum TokenKind {
    Number(f64),
-   String(String),
+   String(Rc<str>),
 
-   Identifier(String),
+   Identifier(Rc<str>),
 
    Nil,
    True,
@@ -242,7 +242,7 @@ impl Lexer {
          }
          '"' => {
             let string = self.string()?;
-            Ok(self.token(TokenKind::String(string)))
+            Ok(self.token(TokenKind::String(Rc::from(string))))
          }
 
          c if Self::is_identifier_start_char(c) => {
@@ -250,7 +250,7 @@ impl Lexer {
             Ok(if let Some(keyword) = Self::keyword(identifier) {
                self.token(keyword)
             } else {
-               let identifier = identifier.to_owned();
+               let identifier = Rc::from(identifier);
                self.token(TokenKind::Identifier(identifier))
             })
          }

--- a/mica-language/src/lexer.rs
+++ b/mica-language/src/lexer.rs
@@ -41,6 +41,7 @@ pub enum TokenKind {
    GreaterEqual, // >=
 
    Assign, // =
+   Dot,    // .
 
    LeftParen,  // (
    RightParen, // )
@@ -265,6 +266,8 @@ impl Lexer {
          '>' => {
             Ok(self.single_or_double_char_token(TokenKind::Greater, '=', TokenKind::GreaterEqual))
          }
+
+         '.' => Ok(self.single_char_token(TokenKind::Dot)),
 
          '(' => Ok(self.single_char_token(TokenKind::LeftParen)),
          ')' => Ok(self.single_char_token(TokenKind::RightParen)),

--- a/mica-language/src/lexer.rs
+++ b/mica-language/src/lexer.rs
@@ -23,6 +23,8 @@ pub enum TokenKind {
    Break,
    Return,
 
+   Struct,
+
    Plus,  // +
    Minus, // -
    Star,  // *
@@ -221,6 +223,9 @@ impl Lexer {
          "end" => TokenKind::End,
          "break" => TokenKind::Break,
          "return" => TokenKind::Return,
+
+         "struct" => TokenKind::Struct,
+
          _ => return None,
       })
    }

--- a/mica-language/src/lexer.rs
+++ b/mica-language/src/lexer.rs
@@ -24,6 +24,9 @@ pub enum TokenKind {
    Return,
 
    Struct,
+   Impl,
+   Constructor,
+   Static,
 
    Plus,  // +
    Minus, // -
@@ -233,6 +236,9 @@ impl Lexer {
          "return" => TokenKind::Return,
 
          "struct" => TokenKind::Struct,
+         "impl" => TokenKind::Impl,
+         "constructor" => TokenKind::Constructor,
+         "static" => TokenKind::Static,
 
          _ => return None,
       })

--- a/mica-language/src/parser.rs
+++ b/mica-language/src/parser.rs
@@ -51,7 +51,7 @@ impl Parser {
          | TokenKind::GreaterEqual => 4,
          TokenKind::Plus | TokenKind::Minus => 5,
          TokenKind::Star | TokenKind::Slash => 6,
-         TokenKind::LeftParen => 7,
+         TokenKind::LeftParen | TokenKind::Dot => 7,
          _ => 0,
       }
    }
@@ -351,6 +351,7 @@ impl Parser {
          TokenKind::GreaterEqual => self.binary_operator(left, token, NodeKind::GreaterEqual),
 
          TokenKind::Assign => self.binary_operator(left, token, NodeKind::Assign),
+         TokenKind::Dot => self.binary_operator(left, token, NodeKind::Dot),
 
          TokenKind::LeftParen => self.function_call(left, token),
 

--- a/mica-language/src/parser.rs
+++ b/mica-language/src/parser.rs
@@ -38,6 +38,15 @@ impl Parser {
       }
    }
 
+   fn try_next(&mut self, kind: TokenKind) -> Result<Option<Token>, Error> {
+      let next_token = self.lexer.peek_token()?;
+      Ok(if next_token.kind == kind {
+         Some(self.lexer.next_token()?)
+      } else {
+         None
+      })
+   }
+
    fn precedence(token: &Token) -> i8 {
       match token.kind {
          TokenKind::Or => 1,
@@ -245,9 +254,19 @@ impl Parser {
          let name = p.lexer.next_token()?;
          p.parse_identifier(name)
       })?;
+
+      // We allow either `constructor` or `static`, but not both.
+      let kind = if let Some(token) = self.try_next(TokenKind::Constructor)? {
+         self.ast.build_node(NodeKind::Constructor, ()).with_location(token.location).done()
+      } else if let Some(token) = self.try_next(TokenKind::Static)? {
+         self.ast.build_node(NodeKind::Static, ()).with_location(token.location).done()
+      } else {
+         NodeId::EMPTY
+      };
+
       let parameters = self
          .ast
-         .build_node(NodeKind::Parameters, ())
+         .build_node(NodeKind::Parameters, kind)
          .with_location(left_paren.location)
          .with_children(parameters)
          .done();
@@ -391,6 +410,23 @@ impl Parser {
       Ok(self.ast.build_node(NodeKind::Struct, name).with_location(struct_token.location).done())
    }
 
+   /// Parses an `impl` block.
+   fn parse_impl(&mut self) -> Result<NodeId, Error> {
+      let impl_token = self.lexer.next_token()?;
+      let implementee = self.parse_expression(0)?;
+      let mut items = Vec::new();
+      // Note that we parse any type of item inside of the `impl` block.
+      // The codegen phase is the thing that ensures the items declared are valid.
+      self.parse_terminated_block(&impl_token, &mut items, |k| k == &TokenKind::End)?;
+      let _end = self.lexer.next_token()?;
+      Ok(self
+         .ast
+         .build_node(NodeKind::Impl, implementee)
+         .with_location(impl_token.location)
+         .with_children(items)
+         .done())
+   }
+
    /// Parses a single item.
    fn parse_item(&mut self) -> Result<NodeId, Error> {
       let token = self.lexer.peek_token()?;
@@ -400,6 +436,7 @@ impl Parser {
             self.parse_function(func_token, false)
          }
          TokenKind::Struct => self.parse_struct(),
+         TokenKind::Impl => self.parse_impl(),
          _ => self.parse_expression(0),
       }
    }

--- a/mica-language/src/parser.rs
+++ b/mica-language/src/parser.rs
@@ -307,6 +307,12 @@ impl Parser {
          TokenKind::Minus => self.unary_operator(token, NodeKind::Negate),
          TokenKind::Bang => self.unary_operator(token, NodeKind::Not),
 
+         TokenKind::At => {
+            let name = self.lexer.next_token()?;
+            let name = self.parse_identifier(name)?;
+            Ok(self.ast.build_node(NodeKind::Field, name).with_location(token.location).done())
+         }
+
          TokenKind::LeftParen => {
             let inner = self.parse_expression(0)?;
             if !matches!(self.lexer.next_token()?.kind, TokenKind::RightParen) {

--- a/mica-language/src/parser.rs
+++ b/mica-language/src/parser.rs
@@ -363,6 +363,7 @@ impl Parser {
       matches!(token, TokenKind::LeftParen)
    }
 
+   /// Parses an expression.
    fn parse_expression(&mut self, precedence: i8) -> Result<NodeId, Error> {
       let mut token = self.lexer.next_token()?;
       let mut left = self.parse_prefix(token)?;
@@ -381,6 +382,15 @@ impl Parser {
       Ok(left)
    }
 
+   /// Parses a struct declaration.
+   fn parse_struct(&mut self) -> Result<NodeId, Error> {
+      let struct_token = self.lexer.next_token()?;
+      let name = self.lexer.next_token()?;
+      let name = self.parse_identifier(name)?;
+      Ok(self.ast.build_node(NodeKind::Struct, name).with_location(struct_token.location).done())
+   }
+
+   /// Parses a single item.
    fn parse_item(&mut self) -> Result<NodeId, Error> {
       let token = self.lexer.peek_token()?;
       match &token.kind {
@@ -388,10 +398,12 @@ impl Parser {
             let func_token = self.lexer.next_token()?;
             self.parse_function(func_token, false)
          }
+         TokenKind::Struct => self.parse_struct(),
          _ => self.parse_expression(0),
       }
    }
 
+   /// Parses a Mica program.
    pub fn parse(mut self) -> Result<(Ast, NodeId), Error> {
       let first_token = self.lexer.peek_token()?;
       let mut main = Vec::new();

--- a/mica-language/src/value.rs
+++ b/mica-language/src/value.rs
@@ -210,7 +210,7 @@ impl PartialEq for Value {
 /// is that types do not contain associated fields (Mica does not have static fields.)
 pub struct Struct {
    /// The disptach table of the struct. This may only be set once, and setting it seals the struct.
-   dispatch_table: Rc<DispatchTable>,
+   pub(crate) dispatch_table: Rc<DispatchTable>,
 }
 
 impl Struct {

--- a/mica-language/src/value.rs
+++ b/mica-language/src/value.rs
@@ -93,7 +93,7 @@ impl Value {
    }
 
    /// Ensures the value is a `String`, returning a type mismatch error if that's not the case.
-   pub fn string(&self) -> Result<&str, ErrorKind> {
+   pub fn string(&self) -> Result<&Rc<str>, ErrorKind> {
       if let Value::String(s) = self {
          Ok(s)
       } else {

--- a/mica-language/src/value.rs
+++ b/mica-language/src/value.rs
@@ -198,6 +198,7 @@ impl PartialEq for Value {
          (Self::Number(l), Self::Number(r)) => l == r,
          (Self::String(l), Self::String(r)) => l == r,
          (Self::Function(l), Self::Function(r)) => Rc::ptr_eq(l, r),
+         (Self::Struct(l), Self::Struct(r)) => Rc::ptr_eq(l, r),
          _ => mem::discriminant(self) == mem::discriminant(other),
       }
    }

--- a/mica-language/src/vm.rs
+++ b/mica-language/src/vm.rs
@@ -455,7 +455,11 @@ impl Fiber {
                      env,
                      ErrorKind::MethodDoesNotExist {
                         type_name: Rc::clone(&dtable.type_name),
-                        signature,
+                        signature: FunctionSignature {
+                           // Subtract 1 to omit the receiver from error messages.
+                           arity: signature.arity.map(|x| x - 1),
+                           ..signature
+                        },
                      },
                   ));
                }

--- a/mica-language/src/vm.rs
+++ b/mica-language/src/vm.rs
@@ -1,6 +1,5 @@
 //! The virtual machine.
 
-use std::ops::Deref;
 use std::pin::Pin;
 use std::ptr;
 use std::rc::Rc;

--- a/mica-language/src/vm.rs
+++ b/mica-language/src/vm.rs
@@ -283,6 +283,7 @@ impl Fiber {
                   captures,
                })));
             }
+            Opcode::CreateType => todo!(),
 
             Opcode::AssignGlobal(slot) => {
                let value = self.stack_top().clone();

--- a/mica-language/src/vm.rs
+++ b/mica-language/src/vm.rs
@@ -339,7 +339,7 @@ impl Fiber {
             }
             Opcode::CreateType => {
                let name = unsafe { self.chunk.read_string(&mut self.pc) };
-               let dispatch_table = DispatchTable::new(&format!("type {name}"));
+               let dispatch_table = DispatchTable::new(format!("type {name}").as_str());
                let struct_v = Struct::new_type(Rc::new(dispatch_table));
                self.stack.push(Value::Struct(Rc::new(struct_v)));
             }

--- a/mica-std/src/builtins.rs
+++ b/mica-std/src/builtins.rs
@@ -26,8 +26,8 @@ impl StandardLibrary for Lib {
          .add_function("sqrt", ref_self(f64::sqrt))
    }
 
-   fn define_string(&mut self, builder: TypeBuilder<str>) -> TypeBuilder<str> {
-      builder
+   fn define_string(&mut self, builder: TypeBuilder<Rc<str>>) -> TypeBuilder<Rc<str>> {
+      builder.add_function("cat", |s: &Rc<str>, t: Rc<str>| format!("{}{}", s, t))
    }
 }
 

--- a/mica-std/src/builtins.rs
+++ b/mica-std/src/builtins.rs
@@ -10,15 +10,21 @@ where
 struct Lib;
 
 impl StandardLibrary for Lib {
-   fn define_nil(&mut self, _builder: &mut TypeBuilder<()>) {}
-
-   fn define_boolean(&mut self, _builder: &mut TypeBuilder<bool>) {}
-
-   fn define_number(&mut self, builder: &mut TypeBuilder<f64>) {
-      builder.add_function("sqrt", ref_self(f64::sqrt));
+   fn define_nil(&mut self, builder: TypeBuilder<()>) -> TypeBuilder<()> {
+      builder
    }
 
-   fn define_string(&mut self, _builder: &mut TypeBuilder<&str>) {}
+   fn define_boolean(&mut self, builder: TypeBuilder<bool>) -> TypeBuilder<bool> {
+      builder
+   }
+
+   fn define_number(&mut self, builder: TypeBuilder<f64>) -> TypeBuilder<f64> {
+      builder.add_function("sqrt", ref_self(f64::sqrt))
+   }
+
+   fn define_string(&mut self, builder: TypeBuilder<str>) -> TypeBuilder<str> {
+      builder
+   }
 }
 
 pub fn lib() -> impl StandardLibrary {

--- a/mica-std/src/builtins.rs
+++ b/mica-std/src/builtins.rs
@@ -1,0 +1,26 @@
+use mica_hl::{StandardLibrary, TypeBuilder};
+
+fn ref_self<T, R>(mut f: impl FnMut(T) -> R) -> impl FnMut(&T) -> R
+where
+   T: Copy,
+{
+   move |x| f(*x)
+}
+
+struct Lib;
+
+impl StandardLibrary for Lib {
+   fn define_nil(&mut self, _builder: &mut TypeBuilder<()>) {}
+
+   fn define_boolean(&mut self, _builder: &mut TypeBuilder<bool>) {}
+
+   fn define_number(&mut self, builder: &mut TypeBuilder<f64>) {
+      builder.add_function("sqrt", ref_self(f64::sqrt));
+   }
+
+   fn define_string(&mut self, _builder: &mut TypeBuilder<&str>) {}
+}
+
+pub fn lib() -> impl StandardLibrary {
+   Lib
+}

--- a/mica-std/src/builtins.rs
+++ b/mica-std/src/builtins.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use mica_hl::{StandardLibrary, TypeBuilder};
 
 fn ref_self<T, R>(mut f: impl FnMut(T) -> R) -> impl FnMut(&T) -> R
@@ -19,7 +21,9 @@ impl StandardLibrary for Lib {
    }
 
    fn define_number(&mut self, builder: TypeBuilder<f64>) -> TypeBuilder<f64> {
-      builder.add_function("sqrt", ref_self(f64::sqrt))
+      builder
+         .add_static("parse", |s: Rc<str>| -> Result<f64, _> { s.parse() })
+         .add_function("sqrt", ref_self(f64::sqrt))
    }
 
    fn define_string(&mut self, builder: TypeBuilder<str>) -> TypeBuilder<str> {

--- a/mica-std/src/core.rs
+++ b/mica-std/src/core.rs
@@ -43,9 +43,9 @@ fn assert(condition: Value, message: Option<Value>) -> Result<Value, mica_hl::Er
 
 /// Loads the core library into the engine.
 pub fn load_core(engine: &Engine) -> Result<(), mica_hl::Error> {
-   engine.function("print", print)?;
-   engine.function("error", error)?;
-   engine.function("assert", assert)?;
+   engine.add_function("print", print)?;
+   engine.add_function("error", error)?;
+   engine.add_function("assert", assert)?;
 
    Ok(())
 }

--- a/mica-std/src/lib.rs
+++ b/mica-std/src/lib.rs
@@ -1,9 +1,11 @@
 //! The Mica standard library. Provides functions that can be registered in engines.
 
+mod builtins;
 mod core;
 
 use mica_hl::Engine;
 
+pub use crate::builtins::lib;
 pub use crate::core::load_core;
 
 /// Loads the full standard library into the engine.

--- a/tests/language/struct.mi
+++ b/tests/language/struct.mi
@@ -33,10 +33,37 @@ impl Vector
       @y = y
    end
 
+   # Fields must not be omitted in constructors.
+   func zero() constructor
+   end
+
    func x() @x end
    func y() @y end
+
+   func set_x(x) @x = x end
+   func set_y(y) @y = y end
+
+   func len_sq()
+      @x * @x + @y * @y
+   end
+
+   func len()
+      self.len_sq.sqrt
+   end
 end
 
 v = Vector.new(1, 2)
 assert(v.x == 1)
 assert(v.y == 2)
+v.set_x(4)
+v.set_y(5)
+assert(v.x == 4)
+assert(v.y == 5)
+assert(Vector.new(3, 4).len == 5)
+
+# Two constructed struct instances are never equal to each other.
+u = Vector.new(1, 2)
+v = Vector.new(1, 2)
+assert(u == u)
+assert(v == v)
+assert(u != v)

--- a/tests/language/struct.mi
+++ b/tests/language/struct.mi
@@ -6,3 +6,8 @@ struct Other
 assert(Test == Test)
 assert(Other == Other)
 assert(Test != Other)
+
+# A struct item returns nil.
+assert(do
+   struct Test2
+end == nil)

--- a/tests/language/struct.mi
+++ b/tests/language/struct.mi
@@ -1,0 +1,8 @@
+# Tests the ability to create and implement structs.
+
+# Two defined struct types are never equal to each other.
+struct Test
+struct Other
+assert(Test == Test)
+assert(Other == Other)
+assert(Test != Other)

--- a/tests/language/struct.mi
+++ b/tests/language/struct.mi
@@ -22,3 +22,21 @@ impl Greetings
 end
 
 assert(Greetings.get("World") == "Hello, World!")
+
+# A struct can have a constructor that sets its fields up.
+# It can also have instance methods.
+struct Vector
+
+impl Vector
+   func new(x, y) constructor
+      @x = x
+      @y = y
+   end
+
+   func x() @x end
+   func y() @y end
+end
+
+v = Vector.new(1, 2)
+assert(v.x == 1)
+assert(v.y == 2)

--- a/tests/language/struct.mi
+++ b/tests/language/struct.mi
@@ -11,3 +11,14 @@ assert(Test != Other)
 assert(do
    struct Test2
 end == nil)
+
+# A struct can be implemented with arbitrary methods.
+struct Greetings
+
+impl Greetings
+   func get(for_whom) static
+      "Hello, ".cat(for_whom).cat("!")
+   end
+end
+
+print(Greetings.get("World"))

--- a/tests/language/struct.mi
+++ b/tests/language/struct.mi
@@ -21,4 +21,4 @@ impl Greetings
    end
 end
 
-print(Greetings.get("World"))
+assert(Greetings.get("World") == "Hello, World!")

--- a/tests/language/struct.mi
+++ b/tests/language/struct.mi
@@ -33,8 +33,11 @@ impl Vector
       @y = y
    end
 
-   # Fields must not be omitted in constructors.
+   # There can be more than one constructor. Each constructor after the first one must assign
+   # the same set of fields.
    func zero() constructor
+      @x = 0
+      @y = 0
    end
 
    func x() @x end
@@ -60,6 +63,9 @@ v.set_y(5)
 assert(v.x == 4)
 assert(v.y == 5)
 assert(Vector.new(3, 4).len == 5)
+z = Vector.zero
+assert(z.x == 0)
+assert(z.y == 0)
 
 # Two constructed struct instances are never equal to each other.
 u = Vector.new(1, 2)


### PR DESCRIPTION
- `struct`
  - [x] Syntax
  - [x] Codegen
  - [x] VM
- Instance function calls
  - [x] Syntax
  - [x] Codegen
  - [x] VM
- `impl`
  - [x] Syntax
  - [x] Codegen
  - [x] VM
- Fields
  - [x] Syntax
  - [x] Codegen
  - [x] VM
  - [x] Constructors

Other stuff:
 - [x] Globals for referring to `Nil`, `Boolean`, `Number`, `String`
 - [x] Support for creating `static` functions from `mica-hl`
 - [x] Tests
 - [x] Implement backtracking on number literals such that `4.sqrt` is valid syntax
 - [x] Stack traces don't seem to work properly when an inexistent method is referenced

Standard library stuff is out of scope for this PR.

Closes #13 