### PR TITLE
Engine reentrancy

### DIFF
--- a/examples/hello-mica.rs
+++ b/examples/hello-mica.rs
@@ -3,8 +3,8 @@
 use mica::Engine;
 
 fn main() {
-   let engine = Engine::new(mica::std::lib());
-   mica::std::load(&engine).unwrap();
+   let mut engine = Engine::new(mica::std::lib());
+   mica::std::load(&mut engine).unwrap();
 
    engine.set("x", 123_i32).unwrap();
    engine.set("y", 456_i32).unwrap();

--- a/mica-hl/src/engine.rs
+++ b/mica-hl/src/engine.rs
@@ -92,7 +92,6 @@ impl Engine {
    /// Compiles a script.
    ///
    /// # Errors
-   ///  - [`Error::EngineInUse`] - A fiber is currently running in this engine
    ///  - [`Error::Compile`] - Syntax or semantic error
    pub fn compile(
       &mut self,
@@ -144,7 +143,6 @@ impl Engine {
    /// globals.
    ///
    /// # Errors
-   ///  - [`Error::EngineInUse`] - A fiber is currently running in this engine
    ///  - [`Error::TooManyGlobals`] - Too many globals with unique names were created
    pub fn global_id(&mut self, name: &str) -> Result<GlobalId, Error> {
       if let Some(slot) = self.env.get_global(name) {
@@ -161,7 +159,6 @@ impl Engine {
    /// The `id` parameter can be either an `&str` or a prefetched [`global_id`][`Self::global_id`].
    ///
    /// # Errors
-   ///  - [`Error::EngineInUse`] - A fiber is currently running in this engine
    ///  - [`Error::TooManyGlobals`] - Too many globals with unique names were created
    pub fn set<G, T>(&mut self, id: G, value: T) -> Result<(), Error>
    where
@@ -178,7 +175,6 @@ impl Engine {
    /// The `id` parameter can be either an `&str` or a prefetched [`global_id`][`Self::global_id`].
    ///
    /// # Errors
-   ///  - [`Error::EngineInUse`] - A fiber is currently running in this engine
    ///  - [`Error::TooManyGlobals`] - Too many globals with unique names were created
    ///  - [`Error::TypeMismatch`] - The type of the value is not convertible to `T`
    pub fn get<G, T>(&self, id: G) -> Result<T, Error>
@@ -206,7 +202,6 @@ impl Engine {
    /// checks you may receive a different amount of arguments than specified.
    ///
    /// # Errors
-   ///  - [`Error::EngineInUse`] - A fiber is currently running in this engine
    ///  - [`Error::TooManyGlobals`] - Too many globals with unique names were created
    ///  - [`Error::TooManyFunctions`] - Too many functions were registered into the engine
    pub fn add_raw_function(
@@ -247,7 +242,6 @@ impl Engine {
    /// Declares a type in the global scope.
    ///
    /// # Errors
-   ///  - [`Error::EngineInUse`] - A fiber is currently running in this engine
    ///  - [`Error::TooManyGlobals`] - Too many globals with unique names were created
    ///  - [`Error::TooManyFunctions`] - Too many functions were registered into the engine
    ///  - [`Error::TooManyMethods`] - Too many unique method signatures were created

--- a/mica-hl/src/engine.rs
+++ b/mica-hl/src/engine.rs
@@ -1,4 +1,3 @@
-use std::cell::RefCell;
 use std::ops::Deref;
 use std::rc::Rc;
 
@@ -19,8 +18,6 @@ use crate::{
 
 pub use mica_language::bytecode::ForeignFunction as RawForeignFunction;
 
-use self::rtenv::RuntimeEnvironment;
-
 /// Options for debugging the language implementation.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct DebugOptions {
@@ -32,7 +29,8 @@ pub struct DebugOptions {
 
 /// An execution engine. Contains information about things like globals, registered types, etc.
 pub struct Engine {
-   runtime_env: Rc<RefCell<RuntimeEnvironment>>,
+   pub(crate) env: Environment,
+   pub(crate) globals: Globals,
    debug_options: DebugOptions,
 }
 
@@ -76,11 +74,9 @@ impl Engine {
          function: Rc::new(DispatchTable::new_for_instance("Function")), // TODO
       };
 
-      let engine = Self {
-         runtime_env: Rc::new(RefCell::new(RuntimeEnvironment {
-            env,
-            globals: Globals::new(),
-         })),
+      let mut engine = Self {
+         env,
+         globals: Globals::new(),
          debug_options,
       };
       // Unwrapping here is fine because at this point we haven't got quite that many globals
@@ -99,7 +95,7 @@ impl Engine {
    ///  - [`Error::EngineInUse`] - A fiber is currently running in this engine
    ///  - [`Error::Compile`] - Syntax or semantic error
    pub fn compile(
-      &self,
+      &mut self,
       filename: impl AsRef<str>,
       source: impl Into<String>,
    ) -> Result<Script, Error> {
@@ -111,18 +107,16 @@ impl Engine {
          eprintln!("{:?}", DumpAst(&ast, root_node));
       }
 
-      let mut shared_env = self.runtime_env.try_borrow_mut().map_err(|_| Error::EngineInUse)?;
-      let main_chunk =
-         CodeGenerator::new(module_name, &mut shared_env.env).generate(&ast, root_node)?;
+      let main_chunk = CodeGenerator::new(module_name, &mut self.env).generate(&ast, root_node)?;
       if self.debug_options.dump_bytecode {
          eprintln!("Mica - global environment:");
-         eprintln!("{:#?}", shared_env.env);
+         eprintln!("{:#?}", self.env);
          eprintln!("Mica - main chunk disassembly:");
          eprintln!("{:#?}", main_chunk);
       }
 
       Ok(Script {
-         runtime_env: Rc::clone(&self.runtime_env),
+         engine: self,
          main_chunk,
       })
    }
@@ -134,11 +128,12 @@ impl Engine {
    /// # Errors
    /// See [`compile`][`Self::compile`].
    pub fn start(
-      &self,
+      &mut self,
       filename: impl AsRef<str>,
       source: impl Into<String>,
    ) -> Result<Fiber, Error> {
-      Ok(self.compile(filename, source)?.start())
+      let script = self.compile(filename, source)?;
+      Ok(script.into_fiber())
    }
 
    /// Returns the unique global ID for the global with the given name, or an error if there
@@ -151,13 +146,12 @@ impl Engine {
    /// # Errors
    ///  - [`Error::EngineInUse`] - A fiber is currently running in this engine
    ///  - [`Error::TooManyGlobals`] - Too many globals with unique names were created
-   pub fn global_id(&self, name: &str) -> Result<GlobalId, Error> {
-      let mut runtime_env = self.runtime_env.try_borrow_mut().map_err(|_| Error::EngineInUse)?;
-      if let Some(slot) = runtime_env.env.get_global(name) {
+   pub fn global_id(&mut self, name: &str) -> Result<GlobalId, Error> {
+      if let Some(slot) = self.env.get_global(name) {
          Ok(GlobalId(slot))
       } else {
          Ok(GlobalId(
-            runtime_env.env.create_global(name).map_err(|_| Error::TooManyGlobals)?,
+            self.env.create_global(name).map_err(|_| Error::TooManyGlobals)?,
          ))
       }
    }
@@ -169,14 +163,13 @@ impl Engine {
    /// # Errors
    ///  - [`Error::EngineInUse`] - A fiber is currently running in this engine
    ///  - [`Error::TooManyGlobals`] - Too many globals with unique names were created
-   pub fn set<G, T>(&self, id: G, value: T) -> Result<(), Error>
+   pub fn set<G, T>(&mut self, id: G, value: T) -> Result<(), Error>
    where
       G: ToGlobalId,
       T: ToValue,
    {
-      let mut runtime_env = self.runtime_env.try_borrow_mut().map_err(|_| Error::EngineInUse)?;
-      let id = id.to_global_id(&mut runtime_env.env)?;
-      runtime_env.globals.set(id.0, value.to_value());
+      let id = id.to_global_id(&mut self.env)?;
+      self.globals.set(id.0, value.to_value());
       Ok(())
    }
 
@@ -190,12 +183,14 @@ impl Engine {
    ///  - [`Error::TypeMismatch`] - The type of the value is not convertible to `T`
    pub fn get<G, T>(&self, id: G) -> Result<T, Error>
    where
-      G: ToGlobalId,
+      G: TryToGlobalId,
       T: TryFromValue,
    {
-      let mut runtime_env = self.runtime_env.try_borrow_mut().map_err(|_| Error::EngineInUse)?;
-      let id = id.to_global_id(&mut runtime_env.env)?;
-      T::try_from_value(&runtime_env.globals.get(id.0))
+      if let Some(id) = id.try_to_global_id(&self.env) {
+         T::try_from_value(&self.globals.get(id.0))
+      } else {
+         T::try_from_value(&Value::Nil)
+      }
    }
 
    /// Declares a "raw" function in the global scope. Raw functions do not perform any type checks
@@ -215,14 +210,13 @@ impl Engine {
    ///  - [`Error::TooManyGlobals`] - Too many globals with unique names were created
    ///  - [`Error::TooManyFunctions`] - Too many functions were registered into the engine
    pub fn add_raw_function(
-      &self,
+      &mut self,
       name: &str,
       parameter_count: impl Into<Option<u16>>,
       f: RawForeignFunction,
    ) -> Result<(), Error> {
-      let mut runtime_env = self.runtime_env.try_borrow_mut().map_err(|_| Error::EngineInUse)?;
-      let global_id = name.to_global_id(&mut runtime_env.env)?;
-      let function_id = runtime_env
+      let global_id = name.to_global_id(&mut self.env)?;
+      let function_id = self
          .env
          .create_function(Function {
             name: Rc::from(name),
@@ -234,7 +228,7 @@ impl Engine {
          function_id,
          captures: Vec::new(),
       }));
-      runtime_env.globals.set(global_id.0, function);
+      self.globals.set(global_id.0, function);
       Ok(())
    }
 
@@ -242,7 +236,7 @@ impl Engine {
    ///
    /// # Errors
    /// See [`add_raw_function`][`Self::add_raw_function`].
-   pub fn add_function<F, V>(&self, name: &str, f: F) -> Result<(), Error>
+   pub fn add_function<F, V>(&mut self, name: &str, f: F) -> Result<(), Error>
    where
       V: ffvariants::Bare,
       F: ForeignFunction<V>,
@@ -257,48 +251,36 @@ impl Engine {
    ///  - [`Error::TooManyGlobals`] - Too many globals with unique names were created
    ///  - [`Error::TooManyFunctions`] - Too many functions were registered into the engine
    ///  - [`Error::TooManyMethods`] - Too many unique method signatures were created
-   pub fn add_type<T>(&self, builder: TypeBuilder<T>) -> Result<(), Error> {
-      let built = {
-         let mut runtime_env = self.runtime_env.try_borrow_mut().map_err(|_| Error::EngineInUse)?;
-         builder.build(&mut runtime_env.env)?
-      };
+   pub fn add_type<T>(&mut self, builder: TypeBuilder<T>) -> Result<(), Error> {
+      let built = { builder.build(&mut self.env)? };
       self.set_built_type(&built)?;
       Ok(())
    }
 
-   pub(crate) fn set_built_type(&self, typ: &BuiltType) -> Result<(), Error> {
+   pub(crate) fn set_built_type(&mut self, typ: &BuiltType) -> Result<(), Error> {
       self.set(typ.type_name.deref(), typ.make_type_struct())
    }
 }
 
-pub(crate) mod rtenv {
-   use mica_language::bytecode::Environment;
-   use mica_language::vm::Globals;
-
-   /// The runtime environment. Contains declared globals and their values.
-   pub struct RuntimeEnvironment {
-      pub(crate) env: Environment,
-      pub(crate) globals: Globals,
-   }
-
-   impl RuntimeEnvironment {
-      pub fn split(&mut self) -> (&mut Environment, &mut Globals) {
-         (&mut self.env, &mut self.globals)
-      }
-   }
-}
-
 /// A script pre-compiled into bytecode.
-pub struct Script {
-   runtime_env: Rc<RefCell<RuntimeEnvironment>>,
+pub struct Script<'e> {
+   engine: &'e mut Engine,
    main_chunk: Rc<Chunk>,
 }
 
-impl Script {
+impl<'e> Script<'e> {
    /// Starts running a script in a new fiber.
-   pub fn start(&self) -> Fiber {
+   pub fn start(&mut self) -> Fiber {
       Fiber {
-         runtime_env: Rc::clone(&self.runtime_env),
+         engine: self.engine,
+         inner: vm::Fiber::new(Rc::clone(&self.main_chunk)),
+      }
+   }
+
+   /// Starts running a script in a new fiber, consuming the script.
+   pub fn into_fiber(self) -> Fiber<'e> {
+      Fiber {
+         engine: self.engine,
          inner: vm::Fiber::new(Rc::clone(&self.main_chunk)),
       }
    }
@@ -338,5 +320,23 @@ impl ToGlobalId for &str {
       } else {
          env.create_global(*self).map(GlobalId).map_err(|_| Error::TooManyGlobals)?
       })
+   }
+}
+
+/// A trait for names convertible to global IDs.
+pub trait TryToGlobalId {
+   #[doc(hidden)]
+   fn try_to_global_id(&self, env: &Environment) -> Option<GlobalId>;
+}
+
+impl TryToGlobalId for GlobalId {
+   fn try_to_global_id(&self, _: &Environment) -> Option<GlobalId> {
+      Some(*self)
+   }
+}
+
+impl TryToGlobalId for &str {
+   fn try_to_global_id(&self, env: &Environment) -> Option<GlobalId> {
+      env.get_global(*self).map(GlobalId)
    }
 }

--- a/mica-hl/src/error.rs
+++ b/mica-hl/src/error.rs
@@ -15,8 +15,6 @@ pub enum Error {
    Compile(LanguageError),
    /// An error occured during runtime.
    Runtime(LanguageError),
-   /// The execution engine is in use.
-   EngineInUse,
    /// There are too many globals.
    TooManyGlobals,
    /// Too many functions were created.
@@ -55,7 +53,6 @@ impl fmt::Display for Error {
    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
       match self {
          Self::Compile(error) | Self::Runtime(error) => error.fmt(f),
-         Self::EngineInUse => f.write_str("execution engine is in use by another fiber"),
          Self::TooManyGlobals => f.write_str("too many globals"),
          Self::TooManyFunctions => f.write_str("too many functions"),
          Self::TooManyMethods => f.write_str("too many methods with different signatures"),

--- a/mica-hl/src/fiber.rs
+++ b/mica-hl/src/fiber.rs
@@ -1,25 +1,15 @@
-use std::cell::RefCell;
-use std::rc::Rc;
-
 use mica_language::value::Value;
 use mica_language::vm;
 
-use crate::rtenv::RuntimeEnvironment;
-use crate::{Error, TryFromValue};
+use crate::{Engine, Error, TryFromValue};
 
 /// A fiber represents an independent, pausable thread of code execution.
-///
-/// # Reentrancy
-///
-/// Note that fibers are not reentrant: an engine can only be running a single fiber at a time,
-/// due to Rust's exclusive mutability constraints. Trying to run two fibers at the same time will
-/// result in a panic.
-pub struct Fiber {
-   pub(crate) runtime_env: Rc<RefCell<RuntimeEnvironment>>,
+pub struct Fiber<'e> {
+   pub(crate) engine: &'e mut Engine,
    pub(crate) inner: vm::Fiber,
 }
 
-impl Fiber {
+impl<'e> Fiber<'e> {
    /// Resumes execution of a fiber. If execution is done already, returns `None`.
    pub fn resume<T>(&mut self) -> Result<Option<T>, Error>
    where
@@ -28,8 +18,7 @@ impl Fiber {
       if self.inner.halted() {
          Ok(None)
       } else {
-         let mut runtime_env = self.runtime_env.try_borrow_mut().map_err(|_| Error::EngineInUse)?;
-         let (env, globals) = runtime_env.split();
+         let Engine { env, globals, .. } = self.engine;
          let result = self.inner.interpret(env, globals)?;
          Ok(Some(T::try_from_value(&result)?))
       }

--- a/mica-hl/src/fiber.rs
+++ b/mica-hl/src/fiber.rs
@@ -1,5 +1,6 @@
+use mica_language::bytecode::Environment;
 use mica_language::value::Value;
-use mica_language::vm;
+use mica_language::vm::{self, Globals};
 
 use crate::{Engine, Error, TryFromValue};
 
@@ -18,8 +19,7 @@ impl<'e> Fiber<'e> {
       if self.inner.halted() {
          Ok(None)
       } else {
-         let Engine { env, globals, .. } = self.engine;
-         let result = self.inner.interpret(env, globals)?;
+         let result = self.inner.interpret(&mut *self.engine)?;
          Ok(Some(T::try_from_value(&result)?))
       }
    }
@@ -37,5 +37,23 @@ impl<'e> Fiber<'e> {
          result = v;
       }
       T::try_from_value(&result)
+   }
+}
+
+impl vm::UserState for &mut Engine {
+   fn env(&self) -> &Environment {
+      &self.env
+   }
+
+   fn globals(&self) -> &Globals {
+      &self.globals
+   }
+
+   fn env_mut(&mut self) -> &mut Environment {
+      &mut self.env
+   }
+
+   fn globals_mut(&mut self) -> &mut Globals {
+      &mut self.globals
    }
 }

--- a/mica-language/src/bytecode.rs
+++ b/mica-language/src/bytecode.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::collections::HashMap;
 use std::fmt::{self, Debug};
 use std::mem::size_of;
@@ -8,7 +7,6 @@ use bytemuck::{Pod, Zeroable};
 
 use crate::common::{ErrorKind, Location};
 use crate::value::{Closure, Value};
-use crate::vm::UserState;
 
 /// A 24-bit integer encoding an instruction operand.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]

--- a/mica-language/src/bytecode.rs
+++ b/mica-language/src/bytecode.rs
@@ -560,7 +560,7 @@ impl Environment {
    }
 
    /// Tries to look up a global. Returns `None` if the global doesn't exist.
-   pub fn get_global(&mut self, name: &str) -> Option<Opr24> {
+   pub fn get_global(&self, name: &str) -> Option<Opr24> {
       self.globals.get(name).copied()
    }
 

--- a/mica-language/src/bytecode.rs
+++ b/mica-language/src/bytecode.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::collections::HashMap;
 use std::fmt::{self, Debug};
 use std::mem::size_of;
@@ -7,6 +8,7 @@ use bytemuck::{Pod, Zeroable};
 
 use crate::common::{ErrorKind, Location};
 use crate::value::{Closure, Value};
+use crate::vm::UserState;
 
 /// A 24-bit integer encoding an instruction operand.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]

--- a/mica-std/src/core.rs
+++ b/mica-std/src/core.rs
@@ -52,7 +52,7 @@ fn assert(condition: Value, message: Option<Value>) -> Result<Value, mica_hl::Er
 }
 
 /// Loads the core library into the engine.
-pub fn load_core(engine: &Engine) -> Result<(), mica_hl::Error> {
+pub fn load_core(engine: &mut Engine) -> Result<(), mica_hl::Error> {
    engine.add_function("print", print)?;
    engine.add_function("debug", debug)?;
    engine.add_function("error", error)?;

--- a/mica-std/src/lib.rs
+++ b/mica-std/src/lib.rs
@@ -9,7 +9,7 @@ pub use crate::builtins::lib;
 pub use crate::core::load_core;
 
 /// Loads the full standard library into the engine.
-pub fn load(engine: &Engine) -> Result<(), mica_hl::Error> {
+pub fn load(engine: &mut Engine) -> Result<(), mica_hl::Error> {
    load_core(engine)?;
 
    Ok(())


### PR DESCRIPTION
Not quite reentrancy, but this removes the `EngineInUse` error in favor of just using the borrow checker.